### PR TITLE
include amazon aws example and startup sshd after openvpn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 fetched_creds
 *.retry
 /inventory
+.DS_Store
+playbooks/group_vars/all.yml
+playbooks/group_vars/openvpn-vpn.yml

--- a/inventory.example
+++ b/inventory.example
@@ -5,6 +5,8 @@
 [openvpn-internet]
 # Typical Digital Ocean config w/ root user and pub/priv key authentication
 #255.255.255.255 ansible_user=root
+# Typical Amazon AWS Ubuntu config w/ sudo user ubuntu and pub/priv key authentication
+#255.255.255.255 ansible_user=ubuntu ansible_become_user=root ansible_become=yes
 # Typical azure config w/ ssh authentication
 #255.255.255.255 ansible_user=vpnuser ansible_become=yes
 # Config for a machine with pub/priv key and password

--- a/playbooks/roles/openvpn/tasks/openvpn.yml
+++ b/playbooks/roles/openvpn/tasks/openvpn.yml
@@ -4,6 +4,11 @@
     name: net.ipv4.ip_forward
     value: 1
 
+- name: OpenVPN | Configuration | Copy sshd service file into place
+  template:
+    src: sshd.service.j2
+    dest: "/lib/systemd/system/ssh.service"
+
 - name: OpenVPN | Configuration | Copy OpenVPN server configuration files into place
   template:
     src: etc_openvpn_server.conf.j2

--- a/playbooks/roles/openvpn/templates/sshd.service.j2
+++ b/playbooks/roles/openvpn/templates/sshd.service.j2
@@ -1,0 +1,18 @@
+[Unit]
+Description=OpenBSD Secure Shell server
+Wants=sys-devices-virtual-net-tun-udp-1194.device
+After=network.target auditd.service sys-devices-virtual-net-tun-udp-1194.device
+ConditionPathExists=!/etc/ssh/sshd_not_to_be_run
+
+[Service]
+EnvironmentFile=-/etc/default/ssh
+ExecStart=/usr/sbin/sshd -D $SSHD_OPTS
+ExecReload=/bin/kill -HUP $MAINPID
+KillMode=process
+Restart=on-failure
+RestartPreventExitStatus=255
+Type=notify
+
+[Install]
+WantedBy=multi-user.target
+Alias=sshd.service


### PR DESCRIPTION
An issue with this playbook is that the sshd service often get's stopped on reboot.

This can make this playbook impossible to use on Amazon AWS since there is no console -- you just get locked out of ssh whether or not you have connect via openvpn. 

I modified the playbook to fix this, by specifying that the sshd service should startup only after the openvpn tunnel device is setup. This is accomplished by modifying the systemd file for the ssh service (/lib/systemd/system/ssh.service).

This is inspired from: https://btux1984.wordpress.com/2015/10/15/start-a-service-after-openvpn-connection-has-been-established-using-systemd/

This method circumvents the usual method of defining an "up.sh" script which starts ssh after openvpn startup that is usually recommended (see: https://unix.stackexchange.com/questions/144992/starting-ssh-server-after-vpn-starts), but which DOES NOT work here because openvpn does not have root privileges in this hardened setup and so cannot execute the restart command.

I also added a typical AWS example (assuming ubuntu 16.04) to inventory.example, which sudo user name ubuntu (as is typical on AWS).


**Tested on Ubuntu 16.04 x64. Not sure it will work on the other supported distros, maybe the location of the ssh.service file is different or it's contents are.**